### PR TITLE
fix: update import paths

### DIFF
--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.ibm.com/open-z/wharf/internal/tags"
-	"github.ibm.com/open-z/wharf/internal/util"
+	"github.com/zosopentools/wharf/internal/tags"
+	"github.com/zosopentools/wharf/internal/util"
 )
 
 type importCycleError struct {

--- a/internal/porting/patch.go
+++ b/internal/porting/patch.go
@@ -11,9 +11,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.ibm.com/open-z/wharf/internal/direct"
-	"github.ibm.com/open-z/wharf/internal/packages"
-	"github.ibm.com/open-z/wharf/internal/util"
+	"github.com/zosopentools/wharf/internal/direct"
+	"github.com/zosopentools/wharf/internal/packages"
+	"github.com/zosopentools/wharf/internal/util"
 )
 
 type modulepatch struct {

--- a/internal/porting/port.go
+++ b/internal/porting/port.go
@@ -13,10 +13,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.ibm.com/open-z/wharf/internal/direct"
-	"github.ibm.com/open-z/wharf/internal/packages"
-	"github.ibm.com/open-z/wharf/internal/tags"
-	"github.ibm.com/open-z/wharf/internal/util"
+	"github.com/zosopentools/wharf/internal/direct"
+	"github.com/zosopentools/wharf/internal/packages"
+	"github.com/zosopentools/wharf/internal/tags"
+	"github.com/zosopentools/wharf/internal/util"
 )
 
 // Comments added to files that are altered by Wharf

--- a/internal/porting/setup.go
+++ b/internal/porting/setup.go
@@ -13,7 +13,7 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.ibm.com/open-z/wharf/internal/direct"
+	"github.com/zosopentools/wharf/internal/direct"
 )
 
 type Config struct {

--- a/internal/porting/states.go
+++ b/internal/porting/states.go
@@ -5,7 +5,7 @@
 package porting
 
 import (
-	"github.ibm.com/open-z/wharf/internal/packages"
+	"github.com/zosopentools/wharf/internal/packages"
 )
 
 // pstate states

--- a/main.go
+++ b/main.go
@@ -12,9 +12,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.ibm.com/open-z/wharf/internal/direct"
-	"github.ibm.com/open-z/wharf/internal/porting"
-	"github.ibm.com/open-z/wharf/internal/util"
+	"github.com/zosopentools/wharf/internal/direct"
+	"github.com/zosopentools/wharf/internal/porting"
+	"github.com/zosopentools/wharf/internal/util"
 )
 
 var dryRunFlag *bool


### PR DESCRIPTION
Fixes the issue when using `go install` where the import path doesn't match the actual repository location


related #12 
closes #11 