### PR TITLE
feat: add long flag for tests that require more run time

### DIFF
--- a/internal/modtest/docker_client.yaml
+++ b/internal/modtest/docker_client.yaml
@@ -1,3 +1,4 @@
 module: github.com/docker/docker
 paths:
  - github.com/docker/docker/client
+long: true

--- a/internal/modtest/filebeat.yaml
+++ b/internal/modtest/filebeat.yaml
@@ -1,3 +1,4 @@
 module: github.com/elastic/beats
 paths:
  - github.com/elastic/beats/filebeat
+long: true

--- a/internal/modtest/mmap_go.yaml
+++ b/internal/modtest/mmap_go.yaml
@@ -1,1 +1,2 @@
 module: github.com/elastic/mmap-go
+long: true

--- a/internal/modtest/prometheus.yaml
+++ b/internal/modtest/prometheus.yaml
@@ -2,3 +2,4 @@ module: github.com/prometheus/prometheus
 paths:
   - github.com/prometheus/prometheus/cmd/...
 version: v2.37.6
+long: true


### PR DESCRIPTION
To enable the tests run add the -long flag as an argument when running go test. The currently disabled tests will still fail, so the long flag currently is being used as a means to disable some tests that are broken not due to Wharf, but as of the current testing infrastructure.