### PR TITLE
fix: breaking API changes in Go 1.20

### DIFF
--- a/internal/packages/load.go
+++ b/internal/packages/load.go
@@ -442,6 +442,12 @@ func loadBuildConfigs(fset *token.FileSet, jpkg *RawPackage, loadAllConfigs bool
 
 		builds[0].GoFiles = append(builds[0].GoFiles, gofile)
 
+		// Don't check tags for GOROOT packages (see https://github.com/ZOSOpenTools/wharf/issues/7)
+		if jpkg.Goroot {
+			alwaysBuild = append(alwaysBuild, gofile)
+			continue
+		}
+
 		switch cnstr := cstr.(type) {
 		case tags.All:
 			alwaysBuild = append(alwaysBuild, gofile)

--- a/internal/porting/port.go
+++ b/internal/porting/port.go
@@ -334,7 +334,7 @@ func port(pkg *packages.Package, cfg *Config) error {
 		})
 
 		if pkg.CfgIdx >= len(pkg.Configs) {
-			return fmt.Errorf("")
+			return fmt.Errorf("unable to find a valid config")
 		}
 
 		if len(imports) == 0 {


### PR DESCRIPTION
Multiple API/Go syntax changes broke Wharf in Go 1.20. This PR includes commits that fix them.