### PR TITLE
feat: add flag for custom import directory

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require golang.org/x/sys v0.6.0 // indirect
+require (
+	github.com/mattn/go-isatty v0.0.18 // indirect
+	golang.org/x/sys v0.6.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
+github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=

--- a/mod_test.go
+++ b/mod_test.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/zosopentools/wharf/internal/util"
 	"golang.org/x/tools/go/vcs"
 	"gopkg.in/yaml.v3"
 )
@@ -134,6 +135,11 @@ func run(repo *vcs.RepoRoot, module string, paths []string, version string, t *t
 		os.Unsetenv("GOWORK")
 	})
 
+	goenv, err := util.GoEnv()
+	if err != nil {
+		t.Fatal("Unable to read 'go env':", err)
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
 			t.Fatal(r)
@@ -141,7 +147,7 @@ func run(repo *vcs.RepoRoot, module string, paths []string, version string, t *t
 	}()
 
 	// TODO: set up a test build for this that runs in a child executable
-	if err := main1(paths, "", false, false, false); err != nil {
+	if err := main1(paths, []string{}, false, false, false, filepath.Join(dir, "wharf_port"), goenv); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This change also fixes an issue when porting the module github.com/caddyserver/caddy where two of the dependencies slightly overlap causing the copy to fail. Now Wharf will investigate to see if the root "copy imports directory" exists, and if it does it will warn the user and request confirmation. If STDIN is not a TTY, it will just abort unless a new flag (-f) is passed in.