### PR TITLE
Start collecting patches for deps

### DIFF
--- a/deps-patches/azure-sdk-for-go--sdk-storage-azblob-v1.2.0.patch
+++ b/deps-patches/azure-sdk-for-go--sdk-storage-azblob-v1.2.0.patch
@@ -1,0 +1,103 @@
+From a83b60c3f3e45def5b102378cdb854a3209a1831 Mon Sep 17 00:00:00 2001
+From: v1gnesh <v1gnesh@users.noreply.github.com>
+Date: Sun, 26 Nov 2023 08:12:38 +0000
+Subject: [PATCH] Add zOS support
+
+---
+ sdk/storage/azblob/internal/shared/mmf_zos.go | 38 +++++++++++++++++++
+ sdk/storage/azfile/file/mmf_zos.go            | 38 +++++++++++++++++++
+ 2 files changed, 76 insertions(+)
+ create mode 100644 sdk/storage/azblob/internal/shared/mmf_zos.go
+ create mode 100644 sdk/storage/azfile/file/mmf_zos.go
+
+diff --git a/sdk/storage/azblob/internal/shared/mmf_zos.go b/sdk/storage/azblob/internal/shared/mmf_zos.go
+new file mode 100644
+index 0000000000..7256142b57
+--- /dev/null
++++ b/sdk/storage/azblob/internal/shared/mmf_zos.go
+@@ -0,0 +1,38 @@
++//go:build go1.18 && zos
++// +build go1.18
++// +build zos
++
++// Copyright (c) Microsoft Corporation. All rights reserved.
++// Licensed under the MIT License. See License.txt in the project root for license information.
++
++package shared
++
++import (
++	"fmt"
++	"os"
++	"syscall"
++)
++
++// mmb is a memory mapped buffer
++type Mmb []byte
++
++// newMMB creates a new memory mapped buffer with the specified size
++func NewMMB(size int64) (Mmb, error) {
++	prot, flags := syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_PRIVATE
++	addr, err := syscall.Mmap(-1, 0, int(size), prot, flags)
++	if err != nil {
++		return nil, os.NewSyscallError("Mmap", err)
++	}
++	return Mmb(addr), nil
++}
++
++// delete cleans up the memory mapped buffer
++func (m *Mmb) Delete() {
++	err := syscall.Munmap(*m)
++	*m = nil
++	if err != nil {
++		// if we get here, there is likely memory corruption.
++		// please open an issue https://github.com/Azure/azure-sdk-for-go/issues
++		panic(fmt.Sprintf("Munmap error: %v", err))
++	}
++}
+diff --git a/sdk/storage/azfile/file/mmf_zos.go b/sdk/storage/azfile/file/mmf_zos.go
+new file mode 100644
+index 0000000000..9d972de168
+--- /dev/null
++++ b/sdk/storage/azfile/file/mmf_zos.go
+@@ -0,0 +1,38 @@
++//go:build go1.18 && zos
++// +build go1.18
++// +build zos
++
++// Copyright (c) Microsoft Corporation. All rights reserved.
++// Licensed under the MIT License. See License.txt in the project root for license information.
++
++package file
++
++import (
++	"fmt"
++	"os"
++	"syscall"
++)
++
++// mmb is a memory mapped buffer
++type mmb []byte
++
++// newMMB creates a new memory mapped buffer with the specified size
++func newMMB(size int64) (mmb, error) {
++  prot, flags := syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_PRIVATE
++  addr, err := syscall.Mmap(-1, 0, int(size), prot, flags)
++	if err != nil {
++		return nil, os.NewSyscallError("Mmap", err)
++	}
++	return mmb(addr), nil
++}
++
++// delete cleans up the memory mapped buffer
++func (m *mmb) delete() {
++	err := syscall.Munmap(*m)
++	*m = nil
++	if err != nil {
++		// if we get here, there is likely memory corruption.
++		// please open an issue https://github.com/Azure/azure-sdk-for-go/issues
++		panic(fmt.Sprintf("Munmap error: %v", err))
++	}
++}
+-- 
+2.42.1
+

--- a/deps-patches/machineid--v1.0.1.patch
+++ b/deps-patches/machineid--v1.0.1.patch
@@ -1,0 +1,52 @@
+From 7a071e33e693b65aa7518cb1b87ded64ab43fcce Mon Sep 17 00:00:00 2001
+From: v1gnesh <v1gnesh@users.noreply.github.com>
+Date: Sun, 26 Nov 2023 04:11:49 -0500
+Subject: [PATCH] Add zOS support
+
+---
+ id_zos.go | 33 +++++++++++++++++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+ create mode 100644 id_zos.go
+
+diff --git a/id_zos.go b/id_zos.go
+new file mode 100644
+index 0000000..dd095f7
+--- /dev/null
++++ b/id_zos.go
+@@ -0,0 +1,33 @@
++// +build zos
++
++package machineid
++
++import (
++        "runtime"
++        "unsafe"
++)
++
++func machineID() (string, error) {
++        type sliceHeader struct {
++                addr unsafe.Pointer
++                len  int
++                cap  int
++        }
++
++        cvt := uintptr(*(*int32)(unsafe.Pointer(uintptr(16))))
++        pccaavt := uintptr(*(*int32)(unsafe.Pointer(uintptr(cvt + 764))))
++        pcca := uintptr(*(*int32)(unsafe.Pointer(uintptr(pccaavt))) + 4)
++
++        var b []byte
++        hdr := (*sliceHeader)(unsafe.Pointer(&b))
++        hdr.addr = unsafe.Pointer(pcca)
++        hdr.cap = 12
++        hdr.len = 12
++
++        var res [12]byte
++        copy(res[0:12], b)
++        runtime.CallLeFuncByPtr(runtime.XplinkLibvec+0x6e3<<4,
++                []uintptr{uintptr(unsafe.Pointer(&res[0])), uintptr(12)})
++
++        return string(res[:]), nil
++}
+-- 
+2.42.1
+

--- a/deps-patches/pty--v1.1.20.patch
+++ b/deps-patches/pty--v1.1.20.patch
@@ -1,0 +1,52 @@
+From 65893206ba332d9183f6aa9e8c5b0627da8717f3 Mon Sep 17 00:00:00 2001
+From: v1gnesh <v1gnesh@users.noreply.github.com>
+Date: Sun, 26 Nov 2023 03:18:30 -0500
+Subject: [PATCH] Add zOS support
+
+---
+ ioctl_inner.go |  4 ++--
+ ioctl_zos.go   | 20 ++++++++++++++++++++
+ 2 files changed, 22 insertions(+), 2 deletions(-)
+ create mode 100644 ioctl_zos.go
+
+diff --git a/ioctl_inner.go b/ioctl_inner.go
+index fd5dbef..0ad799a 100644
+--- a/ioctl_inner.go
++++ b/ioctl_inner.go
+@@ -1,5 +1,5 @@
+-//go:build !windows && !solaris && !aix
+-// +build !windows,!solaris,!aix
++//go:build !windows && !solaris && !aix && !zos
++// +build !windows,!solaris,!aix,!zos
+ 
+ package pty
+ 
+diff --git a/ioctl_zos.go b/ioctl_zos.go
+new file mode 100644
+index 0000000..9045f82
+--- /dev/null
++++ b/ioctl_zos.go
+@@ -0,0 +1,20 @@
++//go:build zos
++// +build zos
++
++package pty
++
++import "syscall"
++
++// Local syscall const values.
++const (
++	TIOCGWINSZ = syscall.TIOCGWINSZ
++	TIOCSWINSZ = syscall.TIOCSWINSZ
++)
++
++func ioctl_inner(fd, cmd, ptr uintptr) error {
++  err := syscall.Ioctl(int(fd), int(cmd), ptr)
++	if err != nil {
++		return err
++	}
++	return nil
++}
+-- 
+2.42.1
+

--- a/deps-patches/ristretto--v0.2.3.patch
+++ b/deps-patches/ristretto--v0.2.3.patch
@@ -1,0 +1,88 @@
+From d818c5c960c96e6e6e4826e175eaef95bb062cf3 Mon Sep 17 00:00:00 2001
+From: v1gnesh <v1gnesh@users.noreply.github.com>
+Date: Sun, 26 Nov 2023 03:16:18 -0500
+Subject: [PATCH] Add zOS support
+
+---
+ z/mmap_unix.go |  4 ++--
+ z/mmap_zos.go  | 56 ++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 58 insertions(+), 2 deletions(-)
+ create mode 100644 z/mmap_zos.go
+
+diff --git a/z/mmap_unix.go b/z/mmap_unix.go
+index 629449f..f5166f9 100644
+--- a/z/mmap_unix.go
++++ b/z/mmap_unix.go
+@@ -1,5 +1,5 @@
+-//go:build !windows && !darwin && !plan9 && !linux && !wasip1
+-// +build !windows,!darwin,!plan9,!linux,!wasip1
++//go:build !windows && !darwin && !plan9 && !linux && !wasip1 && !zos
++// +build !windows,!darwin,!plan9,!linux,!wasip1,!zos
+ 
+ /*
+  * Copyright 2019 Dgraph Labs, Inc. and Contributors
+diff --git a/z/mmap_zos.go b/z/mmap_zos.go
+new file mode 100644
+index 0000000..4add034
+--- /dev/null
++++ b/z/mmap_zos.go
+@@ -0,0 +1,56 @@
++//go:build zos
++// +build zos
++
++/*
++ * Copyright 2019 Dgraph Labs, Inc. and Contributors
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++
++package z
++
++import (
++	"os"
++  "syscall"
++	"golang.org/x/sys/unix"
++)
++
++// Mmap uses the mmap system call to memory-map a file. If writable is true,
++// memory protection of the pages is set so that they may be written to as well.
++func mmap(fd *os.File, writable bool, size int64) ([]byte, error) {
++	mtype := unix.PROT_READ
++	if writable {
++		mtype |= unix.PROT_WRITE
++	}
++	return syscall.Mmap(int(fd.Fd()), 0, int(size), mtype, unix.MAP_SHARED)
++}
++
++// Munmap unmaps a previously mapped slice.
++func munmap(b []byte) error {
++	return syscall.Munmap(b)
++}
++
++// Madvise uses the madvise system call to give advise about the use of memory
++// when using a slice that is memory-mapped to a file. Set the readahead flag to
++// false if page references are expected in random order.
++func madvise(b []byte, readahead bool) error {
++	flags := unix.MADV_NORMAL
++	if !readahead {
++		flags = unix.MADV_RANDOM
++	}
++	return unix.Madvise(b, flags)
++}
++
++func msync(b []byte) error {
++	return unix.Msync(b, unix.MS_SYNC)
++}
+-- 
+2.42.1
+


### PR DESCRIPTION
Working through go project ports, we'll see that there are some deps that are kind of prevalent.
In order to avoid rework where possible, and to keep making wharf "smarter", I think it'll be beneficial to collect patches in this repo.
Logic can be added to wharf to use this "knowledge base".
Will have to work out how to add an amalgamated LICENSE to the `deps-patches` directory too, probably.

**Structure:**
`packagename--tag1~tag2.patch`
`tag1~tag2` means this patch will work for any version within and including these bounds.

**Example usage:**
~Will be public soon in another repo; will link to it here once available.~
https://github.com/ZOSOpenTools/buildkiteport/blob/main/buildenv