### PR TITLE
fix: build package result in build constraints exclude all Go files

### DIFF
--- a/internal/packages/inspect.go
+++ b/internal/packages/inspect.go
@@ -57,6 +57,10 @@ var (
 
 	_NOT_DECLARED_BY_PACKAGE_ERR_MATCHER = regexp.MustCompile(`(\w+) not declared by package (\w+)`)
 	// EBADF not declared by package syscall
+
+
+	// exclude the below error 
+	_BUILD_CONSTRAINS_EXCLUDE_ALL_FILE = regexp.MustCompile(`build constraints exclude all Go files in ([a-zA-Z0-9_/@.]+)`)
 )
 
 type TypeErrId interface {
@@ -129,4 +133,11 @@ func parseTypeErrorReason(err types.Error) TypeErrId {
 	}
 
 	return TCBadOther{}
+}
+
+func IsExcludeGoListError(errMessage string) bool {
+	if _BUILD_CONSTRAINS_EXCLUDE_ALL_FILE.MatchString(errMessage) {
+		return true
+	}
+	return false
 }

--- a/internal/tags/tags.go
+++ b/internal/tags/tags.go
@@ -10,6 +10,9 @@ import (
 	"fmt"
 	"go/build/constraint"
 	"strings"
+	"regexp"
+	"os"
+	"path/filepath"
 )
 
 // All the unix-like platforms, listed in order of build priority
@@ -553,4 +556,23 @@ Lines:
 	}
 
 	return goBuild, nil
+}
+
+func FindPackageName(baseDir string, goFiles []string) string {
+	packageExp := regexp.MustCompile("\n*\\s*package\\s+([a-zA-Z_]+)\\s*")
+	testFileExp := regexp.MustCompile("^[a-zA-Z0-0_]_test.go$")
+	for _, file := range goFiles {
+		if testFileExp.MatchString(file) {
+			continue
+		}
+
+		content, err := os.ReadFile(filepath.Join(baseDir, file))
+		if err != nil {
+			continue
+		}
+		if res := packageExp.FindSubmatch(content); len(res) > 0 {
+			return string(res[1])
+		}
+	}
+	return ""
 }

--- a/internal/util/cmd.go
+++ b/internal/util/cmd.go
@@ -115,7 +115,11 @@ func GoList(pkgs []string) (string, error) {
 // Run go list -find
 func GoListPkgDir(pkg string) (string, error) {
 	cmd := exec.Command("go", "list", "-f", "{{.Dir}}", "-find", "-mod=readonly", pkg)
-	return runout(cmd)
+	out, err := runout(cmd)
+	if err != nil {
+		return "", fmt.Errorf("%v\n %w", out, err)
+	} 
+	return out, err
 }
 
 func GoListModMain(mod string) error {


### PR DESCRIPTION
    This happens when all of the file is tagged for other platforms in a
    package. go list will complain about it can not find any file to
    build