### PR TITLE
 fix: correct the implementation of test

### DIFF
--- a/internal/modtest/bbolt.yaml
+++ b/internal/modtest/bbolt.yaml
@@ -1,1 +1,4 @@
 module: go.etcd.io/bbolt
+go_version: go1.22.1
+# unix.Mmap is not support in z/OS sys/unix
+fails: true

--- a/internal/modtest/etcd_v3.yaml
+++ b/internal/modtest/etcd_v3.yaml
@@ -1,1 +1,7 @@
 module: go.etcd.io/etcd/v3
+
+# it use bbolt which use unix.Mmap
+# unix.Mmap is not support in z/OS sys/unix
+fails: true
+
+go_version: go1.22.0

--- a/internal/modtest/ginkgo_v2.yaml
+++ b/internal/modtest/ginkgo_v2.yaml
@@ -1,1 +1,5 @@
 module: github.com/onsi/ginkgo/v2
+
+# Unknow Failure 
+# TODO: investigate the failure https://github.com/ZOSOpenTools/wharf/issues/38
+long: true

--- a/internal/modtest/gitea.yaml
+++ b/internal/modtest/gitea.yaml
@@ -1,1 +1,6 @@
-module: github.com/go-gitea/gitea
+module: code.gitea.io/gitea
+
+# using bbolt which use unix.Mmap 
+# unix.Mmap is not support in z/OS sys/unix
+# using goleveldb and currently not supporting goleveldb
+fails: true

--- a/internal/modtest/github.yaml
+++ b/internal/modtest/github.yaml
@@ -1,1 +1,3 @@
-module: github.com/github/hub
+module: github.com/github/hub/v2
+
+fails: true

--- a/internal/modtest/go_git.yaml
+++ b/internal/modtest/go_git.yaml
@@ -1,1 +1,1 @@
-module: github.com/go-git/go-git
+module: github.com/go-git/go-git/v5

--- a/internal/modtest/go_txfile.yaml
+++ b/internal/modtest/go_txfile.yaml
@@ -1,1 +1,5 @@
 module: github.com/elastic/go-txfile
+
+# using unix.Mmap 
+# unix.Mmap is not support in z/OS sys/unix
+fails: true

--- a/internal/modtest/goleveldb.yaml
+++ b/internal/modtest/goleveldb.yaml
@@ -1,1 +1,4 @@
 module: github.com/syndtr/goleveldb
+
+# require ginkgo which is not support by wharf
+long: true

--- a/internal/modtest/paxrat.yaml
+++ b/internal/modtest/paxrat.yaml
@@ -1,0 +1,2 @@
+module: github.com/subgraph/paxrat
+go_version: go1.22.0

--- a/internal/modtest/tiedot.yaml
+++ b/internal/modtest/tiedot.yaml
@@ -1,0 +1,2 @@
+module: github.com/HouzuoGuo/tiedot
+go_version: go1.22.0

--- a/internal/packages/packages.go
+++ b/internal/packages/packages.go
@@ -15,6 +15,10 @@ var Goos string
 var BuildTags map[string]bool
 var globalpkgs map[string]*Package = make(map[string]*Package, 50)
 
+func ClearGlobalpkgs() {
+	globalpkgs = make(map[string]*Package, 50)
+}
+
 type ProcGroup struct {
 	Packages []*Package
 


### PR DESCRIPTION
        modtest always passes. This is due to not passing the module path
        to the program and does not produce errors correctly. After
        handling those errors some test cases start failing.
        Also, add a few tests

        there was resource (globalpackages) shared by each run of Port function. The resource
        needs to clean up after each run. Add funtionality to enable Fails
        option for test cases that assert Wharf port is failing. Also, add
        go_version option for the tests that specify a required go version to run
        the test. If the current running go version does not meet the required
        go version, tests will be skipped