### PR TITLE
fix go install instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This program can:
 ### Go Install
 
 ```
-go install github.com/zosopentools/wharf
+go install github.com/zosopentools/wharf@latest
 ```
 
 ### From source


### PR DESCRIPTION
add latest tag when installing wharf in README instruction