### PR TITLE
Removed embedded version tag and use linker flags instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ git clone git@github.com:zosopentools/wharf && cd wharf
 go install
 ```
 
+##### Note: Embedding Version Number
+
+Use the following build command to embed a version number into the executable. Using `--version` will return: `unknown (built from source)` otherwise.
+```
+go install -ldflags="-X 'main.Version=v9.9.9'"
+```
+_Where "v9.9.9" is the appropriate version tag_
+
 ## Usage
 
 Run it similarly to `go build`.

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	"github.com/mattn/go-isatty"
@@ -18,7 +19,18 @@ import (
 	"github.com/zosopentools/wharf/internal/util"
 )
 
-var version = "v1.1.0"
+const shaLen = 7
+
+var (
+	// Version contains the application version number. It's set via ldflags
+	// when building. (-ldflags="-X 'main.Version=${WHARF_VERSION}'")
+	Version = ""
+
+	// CommitSHA contains the SHA of the commit that this application was built
+	// against. It's set via ldflags when building.
+	// (-ldflags="-X 'main.CommitSHA=$(git rev-parse HEAD)'")
+	CommitSHA = ""
+)
 
 func main() {
 	opts := make(map[string]any)
@@ -46,7 +58,19 @@ func main() {
 	}
 
 	if *versionFlag {
-		fmt.Println(version)
+		if Version == "" {
+			if info, ok := debug.ReadBuildInfo(); ok && info.Main.Sum != "" {
+				Version = info.Main.Version
+			} else {
+				Version = "unknown (built from source)"
+			}
+		}
+
+		if len(CommitSHA) >= shaLen {
+			Version += " (" + CommitSHA[:shaLen] + ")"
+		}
+
+		fmt.Println(Version)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Embed version number with:
```
go build -ldflags="-X 'main.Version=1.1.3'"
```

This helps us dynamically update the version number for zopen

Will automatically tag with module information if installed from `go install github.com/ZOSOpenTools/wharf@latest`